### PR TITLE
chore: Remove SSH key requirement for Dockerfile, CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ jobs:
           command: "go env"
       - go/load-cache:
           key: go-mod-v6-{{ checksum "go.sum" }}
-      - add_ssh_keys
       - go/mod-download
       - go/save-cache:
           key: go-mod-v6-{{ checksum "go.sum" }}
@@ -46,7 +45,6 @@ jobs:
       resource_class: large
     steps:
       - checkout
-      - add_ssh_keys
       - aws-ecr/build-image:
           push-image: false
           dockerfile: Dockerfile
@@ -54,7 +52,6 @@ jobs:
           build-path: ./
           tag: "$CIRCLE_SHA1,$CIRCLE_TAG"
           repo: "$CIRCLE_PROJECT_REPONAME"
-          extra-build-args: "--secret id=sshKey,src=/home/circleci/.ssh/$DEPLOY_KEY_NAME"
       - run:
           name: Save Docker image to export it to workspace
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,10 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              only:
+                - main
+                - dev
       - push_docker:
           requires:
             - build_docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,11 @@ RUN apk add --no-cache --update openssh git make build-base linux-headers libc-d
                                 pkgconfig zeromq-dev musl-dev alpine-sdk libsodium-dev \
                                 libzmq-static libsodium-static gcc
 
-# Load private repos SSH deploy key and configure ssh
-RUN mkdir -p /root/.ssh && ssh-keyscan github.com >> /root/.ssh/known_hosts
-RUN git config --global url."git@github.com:".insteadOf "https://github.com/"
-ENV GOPRIVATE=github.com/babylonchain/*
-
 # Build
 WORKDIR /go/src/github.com/babylonchain/cli-tools
 # Cache dependencies
 COPY go.mod go.sum /go/src/github.com/babylonchain/cli-tools/
-RUN --mount=type=secret,id=sshKey,target=/root/.ssh/id_rsa  go mod download
+RUN go mod download
 # Copy the rest of the files
 COPY ./ /go/src/github.com/babylonchain/cli-tools/
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(BUILDDIR)/:
 	mkdir -p $(BUILDDIR)/
 
 build-docker:
-	$(DOCKER) build --secret id=sshKey,src=${BBN_PRIV_DEPLOY_KEY} --tag babylonchain/cli-tools -f Dockerfile \
+	$(DOCKER) build --tag babylonchain/cli-tools -f Dockerfile \
 		$(shell git rev-parse --show-toplevel)
 
 .PHONY: build build-docker install tests


### PR DESCRIPTION
Also, build images only for main and dev branches. The docker jobs require secret access which is not granted for forked PRs, resulting in failed CI.