### PR TITLE
hotfix: Bump babylon and renamed magic bytes to tag

### DIFF
--- a/cmd/createStakingTxCmd.go
+++ b/cmd/createStakingTxCmd.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	FlagMagicBytes           = "magic-bytes"
+	FlagTag                  = "tag"
 	FlagStakerPk             = "staker-pk"
 	FlagStakingAmount        = "staking-amount"
 	FlagStakingTime          = "staking-time"
@@ -186,17 +186,17 @@ func parseTimeLock(timeBlocks int64) (uint16, error) {
 	return uint16(timeBlocks), nil
 }
 
-func parseMagicBytesFromHex(magicBytesHex string) ([]byte, error) {
-	magicBytes, err := hex.DecodeString(magicBytesHex)
+func parseTagFromHex(tagHex string) ([]byte, error) {
+	tag, err := hex.DecodeString(tagHex)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(magicBytes) != btcstaking.MagicBytesLen {
-		return nil, fmt.Errorf("magic bytes should be of length %d", btcstaking.MagicBytesLen)
+	if len(tag) != btcstaking.TagLen {
+		return nil, fmt.Errorf("tag should be of length %d", btcstaking.TagLen)
 	}
 
-	return magicBytes, nil
+	return tag, nil
 }
 
 func parsePosNum(num int64) (uint32, error) {
@@ -216,8 +216,8 @@ type CreateStakingTxResp struct {
 }
 
 func init() {
-	createStakingTxCmd.Flags().String(FlagMagicBytes, "", "magic bytes")
-	_ = createStakingTxCmd.MarkFlagRequired(FlagMagicBytes)
+	createStakingTxCmd.Flags().String(FlagTag, "", "tag")
+	_ = createStakingTxCmd.MarkFlagRequired(FlagTag)
 	createStakingTxCmd.Flags().String(FlagStakerPk, "", "staker pk")
 	_ = createStakingTxCmd.MarkFlagRequired(FlagStakerPk)
 	createStakingTxCmd.Flags().String(FlagFinalityProviderPk, "", "finality provider pk")
@@ -246,7 +246,7 @@ var createStakingTxCmd = &cobra.Command{
 			return err
 		}
 
-		magicBytes, err := parseMagicBytesFromHex(mustGetStringFlag(cmd, FlagMagicBytes))
+		tag, err := parseTagFromHex(mustGetStringFlag(cmd, FlagTag))
 
 		if err != nil {
 			return err
@@ -289,7 +289,7 @@ var createStakingTxCmd = &cobra.Command{
 		}
 
 		_, tx, err := btcstaking.BuildV0IdentifiableStakingOutputsAndTx(
-			magicBytes,
+			tag,
 			stakerPk,
 			finalityProviderPk,
 			covenantCommitteePks,

--- a/cmd/createUnbondingTxCmd.go
+++ b/cmd/createUnbondingTxCmd.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 
 	"github.com/babylonchain/babylon/btcstaking"
-	"github.com/babylonchain/cli-tools/internal/btcclient"
-	"github.com/babylonchain/cli-tools/internal/config"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/spf13/cobra"
+
+	"github.com/babylonchain/cli-tools/internal/btcclient"
+	"github.com/babylonchain/cli-tools/internal/config"
 )
 
 var (
@@ -31,8 +32,8 @@ func init() {
 	// parsing it wil fail
 	createUnbondingTxCmd.Flags().String(FlagStakingTxHex, "", "funded staking tx hex")
 	_ = createUnbondingTxCmd.MarkFlagRequired(FlagStakingTxHex)
-	createUnbondingTxCmd.Flags().String(FlagMagicBytes, "", "magic bytes")
-	_ = createUnbondingTxCmd.MarkFlagRequired(FlagMagicBytes)
+	createUnbondingTxCmd.Flags().String(FlagTag, "", "tag")
+	_ = createUnbondingTxCmd.MarkFlagRequired(FlagTag)
 	createUnbondingTxCmd.Flags().Int64(FlagUnbondingTime, 0, "unbonding time")
 	_ = createUnbondingTxCmd.MarkFlagRequired(FlagUnbondingTime)
 	createUnbondingTxCmd.Flags().Int64(FlagUnbondingTxFee, 0, "unbonding fee")
@@ -142,7 +143,7 @@ var createUnbondingTxCmd = &cobra.Command{
 			return err
 		}
 
-		magicBytes, err := parseMagicBytesFromHex(mustGetStringFlag(cmd, FlagMagicBytes))
+		tag, err := parseTagFromHex(mustGetStringFlag(cmd, FlagTag))
 
 		if err != nil {
 			return err
@@ -180,7 +181,7 @@ var createUnbondingTxCmd = &cobra.Command{
 
 		parsedStakingTx, err := btcstaking.ParseV0StakingTx(
 			stakingTx,
-			magicBytes,
+			tag,
 			covenantCommitteePks,
 			covenantQuorum,
 			btcParams,

--- a/cmd/createWithdrawTxCmg.go
+++ b/cmd/createWithdrawTxCmg.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 
 	"github.com/babylonchain/babylon/btcstaking"
-	"github.com/babylonchain/cli-tools/internal/btcclient"
-	"github.com/babylonchain/cli-tools/internal/config"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/spf13/cobra"
+
+	"github.com/babylonchain/cli-tools/internal/btcclient"
+	"github.com/babylonchain/cli-tools/internal/config"
 )
 
 var (
@@ -24,8 +25,8 @@ func init() {
 	// parsing it wil fail
 	createWithdrawCmd.Flags().String(FlagStakingTxHex, "", "funded staking tx hex")
 	_ = createWithdrawCmd.MarkFlagRequired(FlagStakingTxHex)
-	createWithdrawCmd.Flags().String(FlagMagicBytes, "", "magic bytes")
-	_ = createWithdrawCmd.MarkFlagRequired(FlagMagicBytes)
+	createWithdrawCmd.Flags().String(FlagTag, "", "tag")
+	_ = createWithdrawCmd.MarkFlagRequired(FlagTag)
 	createWithdrawCmd.Flags().Int64(FlagWithdrawTxFee, 0, "withdraw fee")
 	_ = createWithdrawCmd.MarkFlagRequired(FlagWithdrawTxFee)
 	createWithdrawCmd.Flags().StringSlice(FlagCovenantCommitteePks, nil, "covenant committee pks")
@@ -74,7 +75,7 @@ var createWithdrawCmd = &cobra.Command{
 			return err
 		}
 
-		magicBytes, err := parseMagicBytesFromHex(mustGetStringFlag(cmd, FlagMagicBytes))
+		tag, err := parseTagFromHex(mustGetStringFlag(cmd, FlagTag))
 
 		if err != nil {
 			return err
@@ -118,7 +119,7 @@ var createWithdrawCmd = &cobra.Command{
 
 		parsedStakingTx, err := btcstaking.ParseV0StakingTx(
 			stakingTx,
-			magicBytes,
+			tag,
 			covenantCommitteePks,
 			covenantQuorum,
 			btcParams,

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.22.3
 toolchain go1.22.4
 
 require (
-	github.com/babylonchain/babylon v0.9.0-rc.1
+	github.com/babylonchain/babylon v0.9.0-rc.3
 	github.com/babylonchain/covenant-signer v0.2.6
 	github.com/babylonchain/networks/parameters v0.2.1
-	github.com/btcsuite/btcd v0.24.0
+	github.com/btcsuite/btcd v0.24.2
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
@@ -262,6 +262,7 @@ require (
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/supranational/blst v0.3.11 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -277,8 +277,8 @@ github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX
 github.com/aws/aws-sdk-go v1.44.312 h1:llrElfzeqG/YOLFFKjg1xNpZCFJ2xraIi3PqSuP+95k=
 github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/babylonchain/babylon v0.9.0-rc.1 h1:mZYKQVHVKFUA2xaEAzJloB1kyePHvZECJPgm3p9TYas=
-github.com/babylonchain/babylon v0.9.0-rc.1/go.mod h1:YFALTW+Kp/b5jSDoA7Z70RggJjAedlmQTrpdeU8c3hY=
+github.com/babylonchain/babylon v0.9.0-rc.3 h1:Coaf37uqVvNBMpR0VR8nRcJsCx9FpAU4psRc5BGK1K8=
+github.com/babylonchain/babylon v0.9.0-rc.3/go.mod h1:QTjpnEAEReQofIpZikCQXUZxSkdK0TrWAUbgxOSF9yA=
 github.com/babylonchain/covenant-signer v0.2.6 h1:Dh72ounwl4WsPVd99IBY7uWlSv7zOXwWeMLOfkEx4+U=
 github.com/babylonchain/covenant-signer v0.2.6/go.mod h1:67vSxNxAi/tfDp0WhVK2Sutj/f/ml1lJERY3asR3VuU=
 github.com/babylonchain/networks/parameters v0.2.1 h1:OKHiCnwL/UdVN17cMwCrHz/bAjO/USauLiPyNlnVl6E=
@@ -304,8 +304,8 @@ github.com/btcsuite/btcd v0.22.0-beta.0.20220207191057-4dc4ff7963b4/go.mod h1:7a
 github.com/btcsuite/btcd v0.23.1/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZgnFpsYY=
 github.com/btcsuite/btcd v0.23.3/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZgnFpsYY=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=
-github.com/btcsuite/btcd v0.24.0 h1:gL3uHE/IaFj6fcZSu03SvqPMSx7s/dPzfpG/atRwWdo=
-github.com/btcsuite/btcd v0.24.0/go.mod h1:K4IDc1593s8jKXIF7yS7yCTSxrknB9z0STzc2j6XgE4=
+github.com/btcsuite/btcd v0.24.2 h1:aLmxPguqxza+4ag8R1I2nnJjSu2iFn/kqtHTIImswcY=
+github.com/btcsuite/btcd v0.24.2/go.mod h1:5C8ChTkl5ejr3WHj8tkQSCmydiMEPB0ZhQhehpq7Dgg=
 github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
 github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf7DClJ3U=

--- a/internal/services/expected_interfaces.go
+++ b/internal/services/expected_interfaces.go
@@ -65,7 +65,7 @@ type BtcSender interface {
 type SystemParams struct {
 	CovenantPublicKeys []*btcec.PublicKey
 	CovenantQuorum     uint32
-	MagicBytes         []byte
+	Tag                []byte
 }
 
 type ParamsRetriever interface {

--- a/internal/services/global_params.go
+++ b/internal/services/global_params.go
@@ -27,6 +27,6 @@ func (g *VersionedParamsRetriever) ParamsByHeight(_ context.Context, height uint
 	return &SystemParams{
 		CovenantPublicKeys: versionedParams.CovenantPks,
 		CovenantQuorum:     versionedParams.CovenantQuorum,
-		MagicBytes:         versionedParams.Tag,
+		Tag:                versionedParams.Tag,
 	}, nil
 }

--- a/internal/services/unbonding_pipeline.go
+++ b/internal/services/unbonding_pipeline.go
@@ -9,15 +9,16 @@ import (
 
 	"github.com/babylonchain/babylon/btcstaking"
 	"github.com/babylonchain/babylon/types"
-	"github.com/babylonchain/cli-tools/internal/btcclient"
-	"github.com/babylonchain/cli-tools/internal/config"
-	"github.com/babylonchain/cli-tools/internal/db"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/prometheus/client_golang/prometheus/push"
+
+	"github.com/babylonchain/cli-tools/internal/btcclient"
+	"github.com/babylonchain/cli-tools/internal/config"
+	"github.com/babylonchain/cli-tools/internal/db"
 )
 
 var (
@@ -58,18 +59,18 @@ func pubKeyToStringCompressed(pubKey *btcec.PublicKey) string {
 type SystemParamsRetriever struct {
 	CovenantPublicKeys []*btcec.PublicKey
 	CovenantQuorum     uint32
-	MagicBytes         []byte
+	Tag                []byte
 }
 
 func NewSystemParamsRetriever(
 	quorum uint32,
 	pubKeys []*btcec.PublicKey,
-	magicBytes []byte,
+	tag []byte,
 ) *SystemParamsRetriever {
 	return &SystemParamsRetriever{
 		CovenantQuorum:     quorum,
 		CovenantPublicKeys: pubKeys,
-		MagicBytes:         magicBytes,
+		Tag:                tag,
 	}
 }
 
@@ -77,7 +78,7 @@ func (p *SystemParamsRetriever) GetParams() (*SystemParams, error) {
 	return &SystemParams{
 		CovenantQuorum:     p.CovenantQuorum,
 		CovenantPublicKeys: p.CovenantPublicKeys,
-		MagicBytes:         p.MagicBytes,
+		Tag:                p.Tag,
 	}, nil
 }
 

--- a/internal/services/unbonding_pipeline_test.go
+++ b/internal/services/unbonding_pipeline_test.go
@@ -5,10 +5,6 @@ import (
 	"testing"
 
 	"github.com/babylonchain/babylon/btcstaking"
-	"github.com/babylonchain/cli-tools/internal/config"
-	"github.com/babylonchain/cli-tools/internal/logger"
-	"github.com/babylonchain/cli-tools/internal/mocks"
-	"github.com/babylonchain/cli-tools/internal/services"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
@@ -17,11 +13,16 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/babylonchain/cli-tools/internal/config"
+	"github.com/babylonchain/cli-tools/internal/logger"
+	"github.com/babylonchain/cli-tools/internal/mocks"
+	"github.com/babylonchain/cli-tools/internal/services"
 )
 
 var (
 	testParams = chaincfg.MainNetParams
-	magicBytes = []byte{0x00, 0x01, 0x02, 0x03}
+	tag        = []byte{0x00, 0x01, 0x02, 0x03}
 )
 
 type MockedDependencies struct {
@@ -56,7 +57,7 @@ func NewUnbondingData(
 	fpKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 	stakingInfo, stakingTx, err := btcstaking.BuildV0IdentifiableStakingOutputsAndTx(
-		magicBytes,
+		tag,
 		stakerPubKey,
 		fpKey.PubKey(),
 		covenantInfo.GetCovenantPublicKeys(),
@@ -183,7 +184,7 @@ func TestValidSigningFlow(t *testing.T) {
 	deps.pr.EXPECT().ParamsByHeight(gomock.Any(), uint64(stakingTxHeight)).Return(&services.SystemParams{
 		CovenantPublicKeys: covenantMembers.GetCovenantPublicKeys(),
 		CovenantQuorum:     covenantQuorum,
-		MagicBytes:         magicBytes,
+		Tag:                tag,
 	}, nil)
 	deps.cs.EXPECT().SignUnbondingTransaction(gomock.Any()).Return(covenantSignatures[0], nil)
 	deps.bs.EXPECT().CheckTxOutSpendable(
@@ -229,7 +230,7 @@ func TestInvalidSignatureHandling(t *testing.T) {
 	deps.pr.EXPECT().ParamsByHeight(gomock.Any(), uint64(stakingTxHeight)).Return(&services.SystemParams{
 		CovenantPublicKeys: covenantMembers.GetCovenantPublicKeys(),
 		CovenantQuorum:     covenantQuorum,
-		MagicBytes:         magicBytes,
+		Tag:                tag,
 	}, nil)
 
 	// tamper signature so it is invalid

--- a/internal/services/witness_gen.go
+++ b/internal/services/witness_gen.go
@@ -58,7 +58,7 @@ func CreateUnbondingPathSpendInfo(
 	net *chaincfg.Params,
 ) (*wire.TxOut, *staking.SpendInfo, error) {
 	info, err := staking.BuildV0IdentifiableStakingOutputs(
-		params.MagicBytes,
+		params.Tag,
 		stakingInfo.StakerPk,
 		stakingInfo.FinalityProviderPk,
 		params.CovenantPublicKeys,

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -62,7 +62,7 @@ type TestManager struct {
 	stakerAddress       btcutil.Address
 	stakerPrivKey       *btcec.PrivateKey
 	stakerPubKey        *btcec.PublicKey
-	magicBytes          []byte
+	tag                 []byte
 	pipeLineConfig      *config.Config
 	pipeLine            *services.UnbondingPipeline
 	testStoreController *services.PersistentUnbondingStorage
@@ -145,8 +145,8 @@ func StartManager(
 	appConfig.Btc.Pass = "pass"
 	appConfig.Btc.Network = netParams.Name
 
-	magicBytes := []byte{0x0, 0x1, 0x2, 0x3}
-	signerCfg, signerGlobalParams, signingServer := startSigningServer(t, magicBytes)
+	tag := []byte{0x0, 0x1, 0x2, 0x3}
+	signerCfg, signerGlobalParams, signingServer := startSigningServer(t, tag)
 
 	appConfig.Signer = *signerCfg
 
@@ -156,7 +156,7 @@ func StartManager(
 		Version:        0,
 		CovenantPks:    signerGlobalParams.Versions[0].CovenantPks,
 		CovenantQuorum: signerGlobalParams.Versions[0].CovenantQuorum,
-		Tag:            magicBytes,
+		Tag:            tag,
 	}
 
 	params := services.VersionedParamsRetriever{
@@ -205,7 +205,7 @@ func StartManager(
 		stakerAddress:       walletAddress,
 		stakerPrivKey:       stakerPrivKey,
 		stakerPubKey:        stakerPrivKey.PubKey(),
-		magicBytes:          []byte{0x0, 0x1, 0x2, 0x3},
+		tag:                 []byte{0x0, 0x1, 0x2, 0x3},
 		pipeLineConfig:      appConfig,
 		pipeLine:            pipeLine,
 		testStoreController: nil,
@@ -226,7 +226,7 @@ func StartManager(
 
 func startSigningServer(
 	t *testing.T,
-	magicBytes []byte,
+	tag []byte,
 ) (*config.RemoteSignerConfig, *parser.ParsedGlobalParams, *signerservice.SigningServer) {
 	appConfig := signercfg.DefaultConfig()
 	appConfig.BtcNodeConfig.Host = "127.0.0.1:18443"
@@ -297,7 +297,7 @@ func startSigningServer(
 				Version:           0,
 				ActivationHeight:  0,
 				StakingCap:        btcutil.Amount(100000000000),
-				Tag:               magicBytes,
+				Tag:               tag,
 				CovenantQuorum:    quorum,
 				CovenantPks:       []*btcec.PublicKey{localCovenantKey1, localCovenantKey2},
 				ConfirmationDepth: 1,
@@ -350,7 +350,7 @@ type stakingTxSigInfo struct {
 
 func (tm *TestManager) sendStakingTxToBtc(d *stakingData) *stakingTxSigInfo {
 	info, err := staking.BuildV0IdentifiableStakingOutputs(
-		tm.magicBytes,
+		tm.tag,
 		tm.stakerPubKey,
 		tm.finalityProviderKey.PubKey(),
 		tm.covenantPublicKeys,
@@ -392,7 +392,7 @@ func (tm *TestManager) createUnbondingTxAndSignByStaker(
 ) *unbondingTxWithMetadata {
 
 	info, err := staking.BuildV0IdentifiableStakingOutputs(
-		tm.magicBytes,
+		tm.tag,
 		tm.stakerPubKey,
 		tm.finalityProviderKey.PubKey(),
 		tm.covenantPublicKeys,


### PR DESCRIPTION
This PR bumpped babylon version and renamed magic bytes to tag, which might affect infra as the flag `--magic-bytes` has changed to `--tag` in some commands. cc @filippos47 